### PR TITLE
feat: add blog, remove placeholders, add README instructions

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,1 @@
+VITE_SITE=http://localhost:4321

--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@
 
 This repository contains the documentation for the [Gram](https://app.getgram.ai) app.
 
+To run
+
+```
+cp .env-example .env
+npm i
+npm run dev
+```
+
+Now you can visit the project locally at http://localhost:4321.
+
 ## 🚀 Project Structure
 
 Inside this Astro + Starlight project, you'll see the following folders and files:

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -74,6 +74,10 @@ export default defineConfig({
           label: "Concepts",
           autogenerate: { directory: "concepts" },
         },
+        {
+          label: "Blog",
+          autogenerate: { directory: "blog" },
+        },
       ],
       plugins: [starlightLlmsTxt()],
     }),

--- a/src/content/docs/blog/hello-world.md
+++ b/src/content/docs/blog/hello-world.md
@@ -1,0 +1,13 @@
+---
+title: Hello World 
+description: News, tips and tricks about Gram and hosted MCP servers
+sidebar:
+  order: 0
+---
+
+Hello, world!
+
+Soon you'll see our first posts here, with more informtion about why we built Gram and what you can do with it.
+
+Stay tuned!
+

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -22,16 +22,16 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 ## Next steps
 
 <CardGrid stagger>
-  <Card title="Update content" icon="pencil">
-    Edit `src/content/docs/index.mdx` to see this page change.
+  <Card title="What is Gram?" icon="pencil">
+    Read our [introduction to Gram](/overview/introduction) to find out more.
   </Card>
-  <Card title="Add new content" icon="add-document">
-    Add Markdown or MDX files to `src/content/docs` to create new pages.
+  <Card title="Gram concepts" icon="add-document">
+    Discover the concepts like [OpenAPI](/concepts/openapi), [Toolsets](/concepts/toolsets) and [Integrations](/concepts/integrations).
   </Card>
-  <Card title="Configure your site" icon="setting">
-    Edit your `sidebar` and other config in `astro.config.mjs`.
+  <Card title="Read our blog" icon="setting">
+    See Gram in action and learn more on our [Blog](/blog/hello-world).
   </Card>
-  <Card title="Read the docs" icon="open-book">
-    Learn more in [the Starlight Docs](https://starlight.astro.build/).
+  <Card title="Discover Speakeasy" icon="open-book">
+    Learn more about [Speakeasy](https://speakeasy.com/), the company behind Gram.
   </Card>
 </CardGrid>


### PR DESCRIPTION
- Add a blog section with a placeholder post
- Remove placeholders from home page and replace with links to posts
- Add .env-example file to run locally more easily
- Add instructions to run site locally to README