### PR TITLE
docs: add responseFilterType property documentation for x-gram extension

### DIFF
--- a/src/content/docs/concepts/openapi.md
+++ b/src/content/docs/concepts/openapi.md
@@ -42,13 +42,14 @@ paths:
         summary: ""
         description: |
           <context>
-            This endpoint returns details about a product for a given merchant. 
+            This endpoint returns details about a product for a given merchant.
           </context>
           <prerequisites>
             - If you are presented with a product or merchant slug then you must first resolve these to their respective IDs.
             - Given a merchant slug use the `resolve_merchant_id` tool to get the merchant ID.
             - Given a product slug use the `resolve_product_id` tool to get the product ID.
           </prerequisites>
+        responseFilterType: jq
       responses:
         "200":
           description: Details about a product
@@ -59,6 +60,28 @@ paths:
 ```
 
 Without the `x-gram` extension, the generated tool would be named `ecommerce_e_commerce_v1_product`, and have the description `"Get a product by its ID"`, resulting in a poor quality tool. The `x-gram` extension allows you to customize a tool's name and description without altering the original information in the OpenAPI document.
+
+### Response Filtering
+
+The `x-gram` extension supports response filtering to help LLMs process API responses more effectively. Use the `responseFilterType` property to specify how responses should be filtered:
+
+- **`jq`**: Enables [jq](https://jqlang.org/) filtering on JSON responses. This allows the LLM to extract specific data from complex API responses using jq syntax, reducing noise and focusing on relevant information.
+
+```yaml
+x-gram:
+  name: get_user_profile
+  description: "Get detailed user profile information"
+  responseFilterType: jq
+```
+
+When `responseFilterType` is set to `jq`, the LLM can apply jq filters to the response data, such as:
+- `.user | {name, email, status}` to extract only specific user fields
+- `.data[] | select(.active == true)` to filter for active items
+- `.results | map({id, title})` to transform arrays of objects
+
+Omitting `responseFilterType` or setting it to `none` disables response filtering.
+
+More response filter types will be available in future releases.
 
 Using the `x-gram` extension is optional. With Gram's [tool variations](/concepts/tool-variations) feature, you can modify a tool's name and description when curating tools into toolsets. However, it might be worth using the `x-gram` extension to make your OpenAPI document clean, descriptive, and LLM-ready before bringing it into Gram, so your team doesn't need to fix tool names and descriptions later.
 


### PR DESCRIPTION
This PR adds documentation for the new `responseFilterType` property in the x-gram extension.

## Changes
- Added `responseFilterType: jq` to the existing x-gram extension example
- Created new "Response Filtering" section documenting the jq filtering capability
- Included practical jq filter examples for common use cases
- Added note about future response filter types

## Context
The x-gram extension now supports response filtering to help LLMs process API responses more effectively. The initial implementation supports jq filtering on JSON responses, allowing LLMs to extract specific data and reduce noise from complex API responses.