### PR TITLE
fix: move building with oauth guide to guides section

### DIFF
--- a/src/content/docs/examples/oauth-external-server.md
+++ b/src/content/docs/examples/oauth-external-server.md
@@ -2,7 +2,7 @@
 title: Build MCP servers with external OAuth
 description: Build OAuth-protected MCP servers with external authentication providers like FusionAuth
 sidebar:
-  order: 7
+  order: 2
 ---
 
 When building production MCP servers, you often need to protect sensitive endpoints with OAuth authentication. This guide shows you how to build an MCP server with external OAuth authentication. We'll use FusionAuth as an example, but you can use any OAuth 2.0 provider you have set up (such as Auth0, Okta, Keycloak, or your own OAuth server).


### PR DESCRIPTION
## Summary
- Move "Build MCP servers with external OAuth" guide from host-mcp section to examples section under guides
- Update sidebar order to 2 for proper positioning in examples section
- Improves discoverability and organization of the OAuth integration guide

## Test plan
- [ ] Verify the guide appears in the Examples section under Guides in the navigation
- [ ] Confirm the guide content displays correctly at the new location
- [ ] Check that all internal links and references still work properly

🤖 Generated with [Claude Code](https://claude.ai/code)